### PR TITLE
Add contributor's guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Welcome to the CNB community! We're happy to have you.
 
-This document is an entry-point for joining and contributing to the CNB community, be it through improving documentation, code, etc.
-To promote a welcoming community, we ask that everyone adhere to our [Code of Conduct](https://github.com/buildpacks/.github/blob/master/CODE_OF_CONDUCT.md).
+This document is an entry-point for joining and contributing to the CNB community, be it through improving documentation, code, etc. To promote a welcoming community, we ask that everyone adhere to our [Code of Conduct](https://github.com/buildpacks/.github/blob/master/CODE_OF_CONDUCT.md).
 
 ## Governance
 We make decisions as a group in a variety of public forums. Our governance practices are documented in [GOVERNANCE.md](GOVERNANCE.md).
@@ -13,6 +12,10 @@ Our roadmap, which discusses our current themes and priorities can be found at [
 
 ## Team
 The roster of the current team members can be found at [TEAMS.md](TEAMS.md).
+
+#### Contributor's Guide
+
+Interested in joining the community of contributors? Learn about how _you_ can join the team by reading our [contributor's guide](contributors/guide.md). 
 
 ## Working Groups
 Working group meetings are a great place to more directly communicate with other members of the community. These meetings occur weekly.

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -54,6 +54,20 @@ Additional Capabilities:
 
 Contribution to this project goes beyond the notion of code contributions. We value any help that you may be able to provide.
 
+#### Code
+
+Code contributions to any project repo are always welcomed.
+
+The following repositories  are good starting points for code contributions:
+
+* [libcnb][libcnb-gfi]
+* [lifecycle][lifecycle-gfi]
+* [pack][pack-gfi]
+
+Other repositories that are specialized:
+* [tekton][tekton]
+* [pack-orb][pack-orb]
+
 #### Docs
 
 This involves documenting any aspect of the project. A good starting point to contribute to documentation would revolve around your comprehension or desired area of expertise.
@@ -72,30 +86,6 @@ A few examples of places where documentation would be valuable:
 * Creating [blog][blog] posts.
     * Discuss blog proposals with the [#learning-team][learning-team-slack]
 
-#### Triage
-
-Triaging issues is the process of looking at newly created issues (or following up on issues). There are many benefits our community gain from our current triage process, to name a few:
-
-1. The community receives reasonable response times.
-2. Minimize the number of open "stale" issues.
-3. Ongoing efforts aren't disrupted.
-
-To learn more about how you can help triage issues, check out our dedicated [triage][triage] page.
-
-#### Code
-
-Code contributions to any project repo are always welcomed.
-
-The following repositories  are good starting points for code contributions:
-
-* [libcnb][libcnb-gfi]
-* [lifecycle][lifecycle-gfi]
-* [pack][pack-gfi]
-
-Other repositories that are specialized:
-* [tekton][tekton]
-* [pack-orb][pack-orb]
-
 #### RFCs
 
 RFCs, or Request For Comments, is the process we employ to review project-wide changes. By proposing changes via RFCs, it allows for the entire community to partake in the brainstorming process of applying changes, considering alternatives, impact, and limitations.
@@ -105,6 +95,16 @@ Contributions to the RFC process can take any or all of the following forms:
 * Reviewing and commenting on [RFC Pull Requests][rfcs-prs].
 * Partaking in discussions in [Working Group][working-group] meetings.
 * Proposing changes via [RFCs][rfcs]. 
+
+#### Triage
+
+Triaging issues is the process of looking at newly created issues (or following up on issues). There are many benefits our community gain from our current triage process, to name a few:
+
+1. The community receives reasonable response times.
+2. Minimize the number of open "stale" issues.
+3. Ongoing efforts aren't disrupted.
+
+To learn more about how you can help triage issues, check out our dedicated [triage][triage] page.
 
 ## FAQs
 

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -70,7 +70,7 @@ Other, more specialized, repositories include:
 
 #### Docs
 
-This involves documenting any aspect of the project. A good starting point to contribute to documentation would revolve around your comprehension or desired area of expertise.
+This involves documenting any aspect of the project. A good starting point for contributions to documentation would revolve around your comprehension or desired area of expertise.
 
 A few examples of places where documentation would be valuable:
 

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -41,7 +41,7 @@ Additional Capabilities:
 Maintainers are responsible for objectives and outcomes of the [sub-team][sub-team] they are inducted into.
 
 Additional Responsibilities:
-* Maintain [sub-team][sub-team] associated contributions.
+* Maintain [sub-team][sub-teams] associated contributions.
 * Recruit [Project Contributors](#project-contributor)
 * Review relevant [RFCs][rfcs]
 
@@ -94,7 +94,7 @@ The following repositories  are good starting points for code contributions:
 
 Other repositories that are specialized:
 * [tekton][tekton]
-* [pack-orb][pack-orb-gfi]
+* [pack-orb][pack-orb]
 
 #### RFCs
 
@@ -119,7 +119,10 @@ Contributions to the RFC process can take any or all of the following forms:
 [rfcs-prs]: https://github.com/buildpacks/rfcs/pulls
 [pack]: https://github.com/buildpacks/pack
 [pack-gfi]: https://github.com/buildpacks/pack/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[pack-orb]: https://github.com/buildpacks/pack-orb/issues
 [samples]: https://github.com/buildpacks/samples
 [samples-issues]: https://github.com/buildpacks/samples/issues
+[sub-teams]: https://github.com/buildpacks/community/blob/contributors-guide/GOVERNANCE.md#sub-teams
+[tekton]: https://github.com/tektoncd/catalog/tree/v1beta1/buildpacks
 [triage]: triage.md
 [working-group]: ../#working-groups

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -110,9 +110,9 @@ To learn more about how you can help triage issues, check out our dedicated [tri
 
 - How do I become a project contributor?
     
-    The process for becoming a [project contributor](#project-contributor) simply requires that you actively [contribute](#contributions) to the project. There is no set amount of contributions that are expected, but the more involved you are in the project the more votes that would be tipped in your favor. 
+    The process for becoming a [Project Contributor](#project-contributor) simply requires that you actively [contribute](#contributions) to the project. There is no set amount of contributions that are expected, but the more involved you are in the project the more votes that would be tipped in your favor. 
     
-    Once you've got a decent amount of contributions, you may self-nominate, or be nominated by another team member. The maintainers of said relevant sub-teams will then vote for your election into becoming a project maintainer.
+    Once you've got a decent amount of contributions, you may self-nominate, or be nominated by another team member to become a Project Contributor. The maintainers of said relevant sub-teams will then vote for your election into becoming a Project Contributor.
 
 <!-- links -->
 [blog]: https://medium.com/buildpacks

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -1,0 +1,125 @@
+# Contributor's Guide
+
+The start of your involvement with the [Cloud Native Buildpacks](https://buildpacks.io/).
+
+### Contributors
+
+```text
++-------------------------+       +-----------------------+       +--------------+
+|                         |       |                       |       |              |
+|  Community Contributor  | +---> |  Project Contributor  | +---> |  Maintainer  |
+|                         |       |                       |       |              |
++-------------------------+       +-----------------------+       +--------------+
+```
+
+Contributors can be broken down into the following tiers.
+
+1. [Community Contributor](#community-contributor)
+2. [Project Contributor](#project-contributor)
+3. [Maintainer](#maintainer)
+
+#### Community Contributor
+
+This is anyone that interacts with this project, creates an issue, opens a PR, adds a comment, etc. You are all in one way
+contributing to a better project.
+
+#### Project Contributor
+
+This group of contributors are recognized as providing sizeable contributions to the project.
+
+Additional Responsibilities:
+* Maintain active participation in project.
+
+Additional Capabilities:
+* Added to GitHub organization team.
+* Ability to edit, label, assign issues.
+* Write access to branches on project repos.
+* Access to infrastructure.
+
+#### Maintainer
+
+Maintainers are responsible for objectives and outcomes of the [sub-team][sub-team] they are inducted into.
+
+Additional Responsibilities:
+* Maintain [sub-team][sub-team] associated contributions.
+* Recruit [Project Contributors](#project-contributor)
+* Review relevant [RFCs][rfcs]
+
+Additional Capabilities:
+* Publish releases.
+* Ability to configure repositories.
+* Invitation to leadership events.
+
+### Contributions
+
+Contribution to this project goes beyond the notion of code contributions. We value any help that you may be able to provide.
+
+#### Docs
+
+This involves documenting any aspect of the project. A good starting point to contribute to documentation would revolve around your comprehension or desired area of expertise.
+
+A few examples of places where documentation would be valuable:
+
+* Providing additional tutorials/guides to our docs site.
+    * [buildpacks.io][buildpacks.io]
+    * [Issues][docs-issues]
+* Adding GoDocs to codebases:
+    * [libcnb][libcnb]
+    * [lifecycle][lifecycle]
+    * [pack][pack]
+* Additional information or examples in our [samples][samples] repo.
+    * [Issues][samples-issues]
+* Creating [blog][blog] posts.
+    * Discuss blog proposals with the [#learning-team][learning-team-slack]
+
+#### Triage
+
+Triaging issues is the process of looking at newly created issues (or following up on issues). There are many benefits our community gain from our current triage process, to name a few:
+
+1. The community receives reasonable response times.
+2. Minimize the number of open "stale" issues.
+3. Ongoing efforts aren't disrupted.
+
+To learn more about how you can help triage issues, check out our dedicated [triage][triage] page.
+
+#### Code
+
+Code contributions to any project repo are always welcomed.
+
+The following repositories  are good starting points for code contributions:
+
+* [libcnb][libcnb-gfi]
+* [lifecycle][lifecycle-gfi]
+* [pack][pack-gfi]
+
+Other repositories that are specialized:
+* [tekton][tekton]
+* [pack-orb][pack-orb-gfi]
+
+#### RFCs
+
+RFCs, or Request For Comments, is the process we employ to review project-wide changes. By proposing changes via RFCs, it allows for the entire community to partake in the brainstorming process of applying changes, considering alternatives, impact, and limitations.
+
+Contributions to the RFC process can take any or all of the following forms:
+
+* Reviewing and commenting on [RFC Pull Requests][rfcs-prs].
+* Partaking in discussions in [Working Group][working-group] meetings.
+* Proposing changes via [RFCs][rfcs]. 
+
+<!-- links -->
+[blog]: https://medium.com/buildpacks
+[buildpacks.io]: https://buildpacks.io/
+[docs-issues]: https://github.com/buildpacks/docs/issues
+[learning-team-slack]: https://buildpacks.slack.com/archives/CST4A3ECV
+[libcnb]: https://github.com/buildpacks/libcnb
+[libcnb-gfi]: https://github.com/buildpacks/libcnb/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[lifecycle]: https://github.com/buildpacks/lifecycle
+[lifecycle-gfi]: https://github.com/buildpacks/lifecycle/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[rfcs]: https://github.com/buildpacks/rfcs
+[rfcs-prs]: https://github.com/buildpacks/rfcs/pulls
+[pack]: https://github.com/buildpacks/pack
+[pack-gfi]: https://github.com/buildpacks/pack/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[samples]: https://github.com/buildpacks/samples
+[samples-issues]: https://github.com/buildpacks/samples/issues
+[triage]: triage.md
+[working-group]: ../#working-groups

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -38,7 +38,7 @@ Additional Capabilities:
 
 #### Maintainer
 
-Maintainers are responsible for objectives and outcomes of the [sub-team][sub-team] they are inducted into.
+Maintainers are responsible for advancing the objectives and outcomes of the [sub-teams][sub-teams] they are inducted into.
 
 Additional Responsibilities:
 * Maintain [sub-team][sub-teams] associated contributions.

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -2,7 +2,7 @@
 
 The start of your involvement with the [Cloud Native Buildpacks](https://buildpacks.io/).
 
-### Contributors
+## Contributors
 
 ```text
 +-------------------------+       +-----------------------+       +--------------+
@@ -50,7 +50,7 @@ Additional Capabilities:
 * Ability to configure repositories.
 * Invitation to leadership events.
 
-### Contributions
+## Contributions
 
 Contribution to this project goes beyond the notion of code contributions. We value any help that you may be able to provide.
 
@@ -105,6 +105,14 @@ Contributions to the RFC process can take any or all of the following forms:
 * Reviewing and commenting on [RFC Pull Requests][rfcs-prs].
 * Partaking in discussions in [Working Group][working-group] meetings.
 * Proposing changes via [RFCs][rfcs]. 
+
+## FAQs
+
+- How do I become a project contributor?
+    
+    The process for becoming a [project contributor](#project-contributor) simply requires that you actively [contribute](#contributions) to the project. There is no set amount of contributions that are expected, but the more involved you are in the project the more votes that would be tipped in your favor. 
+    
+    Once you've got a decent amount of contributions, you may self-nominate, or be nominated by another team member. The maintainers of said relevant sub-teams will then vote for your election into becoming a project maintainer.
 
 <!-- links -->
 [blog]: https://medium.com/buildpacks

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -25,7 +25,7 @@ contributing to a better project.
 
 #### Project Contributor
 
-This group of contributors are recognized as providing sizeable contributions to the project.
+These contributors are recognized as providing sizable contributions to the project.
 
 Additional Responsibilities:
 * Maintain active participation in project.

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -20,7 +20,7 @@ Contributors can be broken down into the following tiers.
 
 #### Community Contributor
 
-This is anyone that interacts with this project, creates an issue, opens a PR, adds a comment, etc. You are all in one way
+This is anyone that interacts with this project, whether it be by creating an issue, opening a PR, adding a comment, etc. You are all, in some way,
 contributing to a better project.
 
 #### Project Contributor

--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -64,7 +64,7 @@ The following repositories  are good starting points for code contributions:
 * [lifecycle][lifecycle-gfi]
 * [pack][pack-gfi]
 
-Other repositories that are specialized:
+Other, more specialized, repositories include:
 * [tekton][tekton]
 * [pack-orb][pack-orb]
 

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -1,6 +1,6 @@
 # Triage
 
-Triaging is the act of managing issues, determining the appropriate response, and following up.
+Triaging is the act of managing issues, determining the appropriate response, and following up with the original poster to ensure the problem was solved.
 
 ### Actionable Issues
 

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -15,7 +15,7 @@ An actionable issue is one that can be worked on such that the following is true
 
 ### Actions
 
-The following is a flow to assist contributors in assigning the appropriate labels in script format.
+The following is a flow to assist contributors in assigning the appropriate labels to an issue.
 
 - Is this a support request?
     - Yes

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -56,7 +56,7 @@ The following is a flow to assist contributors in assigning the appropriate labe
             - Yes
                 - Remove label `status/triage`
                 - Add label `status/ready`
-                - Add appropriate `size/*` (if possible) and `type/*`
+                - Add appropriate `size/*` (if possible), `type/*`, and `good-first-issue` if it is relatively straightforward
             - Sort of - requires additional research
                 - Remove label `status/triage`
                 - Add label `status/ready`

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -4,10 +4,10 @@ Triaging is the act of managing issues, determining the appropriate response, an
 
 ### Actionable Issues
 
-An actionable issue is one that can be worked on such that the following is true:
+An actionable issue is one that can be worked on, such that the following is true:
 
-- Definition of done - that may be acceptance criteria or clear expectations.
-- Appropriate labels
+- A definition of done is provided - whether that is formal acceptance criteria or clear expectations.
+- Appropriate label(s) is present on the issue
     - `type/*`
     - `size/*` (if possible)
     - `status/ready`

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -1,0 +1,77 @@
+# Triage
+
+Triaging is the act of managing issues, determining the appropriate response, and following up.
+
+### Actionable Issues
+
+An actionable issue is one that can be worked on such that the following is true:
+
+- Definition of done - that may be acceptance criteria or clear expectations.
+- Appropriate labels
+    - `type/*`
+    - `size/*` (if possible)
+    - `status/ready`
+    - `good first issue` (if applicable)
+
+### Actions
+
+The following is a flow to assist contributors in assigning the appropriate labels in script format.
+
+- Is this a support request?
+    - Yes
+        - Add label `type/support`
+        - Provide support and close the issue with label `status/resolved`\
+          OR 
+        - Request further information from the issue author and label `status/needs-information`
+        - If activity is missing for 10 days, follow up
+        - If activity is missing for 30 days, close
+    - No
+        - See below
+- Is this something we want to do?
+    - I don’t even understand this issue
+        - Remove label `status/triage`
+        - Add label `status/needs-information`
+        - Comment in request for clarification
+    - No - not valid / relevant for our project
+        - Remove label `status/triage`
+        - Add label `status/invalid`
+        - Comment and close
+    - Maybe - needs RFC
+        - Remove label `status/triage`
+        - Add label `status/requires-rfc`
+        - Comment on suggestion for RFC
+        - If no further activity for 10 days, close
+    - Maybe - needs alignment
+        - Remove label `status/triage`
+        - Add label `status/discussion-needed`
+        - Add appropriate `type/*`
+    - Maybe - I can’t tell from the information in the issue
+        - Remove label `status/triage`
+        - Add label `status/needs-information`
+        - Request further information from issue author
+        - If no further activity for 10 days, close
+    - Yes
+        - Could this be worked on right now?
+            - Yes
+                - Remove label `status/triage`
+                - Add label `status/ready`
+                - Add appropriate `size/*` (if possible) and `type/*`
+            - Sort of - requires additional research
+                - Remove label `status/triage`
+                - Add label `status/ready`
+                - Add label `type/research`
+                - Comment on what information we need from the research task. Outcome of research should yield new issue or close this issue.
+            - No - needs clearer definition of done
+                - Remove label `status/triage`
+                - Add label `status/needs-information`
+                - Add appropriate `size/*` (if possible) and `type/*`
+                - If activity is missing for 10 days, follow up 
+                - If activity is missing for 30 days, close 
+            - No - needs alignment
+                - Remove label `status/triage`
+                - Add label `status/discussion-needed`
+                - Add appropriate `size/*` (if possible) and `type/*`
+            - No - blocked by other work
+                - Remove label `status/triage`
+                - Add label `status/blocked`
+                - Add appropriate `size/*` (if possible) and `type/*`

--- a/contributors/triage.md
+++ b/contributors/triage.md
@@ -32,6 +32,7 @@ The following is a flow to assist contributors in assigning the appropriate labe
         - Remove label `status/triage`
         - Add label `status/needs-information`
         - Comment in request for clarification
+        - If activity is missing for 10 days, close
     - No - not valid / relevant for our project
         - Remove label `status/triage`
         - Add label `status/invalid`


### PR DESCRIPTION
This PR adds a contributor's guide in hope of answering a few recurring questions as well as providing a starting point for on-boarding contributors.

NOTE: The best way to review this is probably to look at the [branch on GH](https://github.com/buildpacks/community/blob/contributors-guide/contributors/guide.md).