### PR TITLE
GHA: Label sync for tekton-integration

### DIFF
--- a/.github/labels/common.yaml
+++ b/.github/labels/common.yaml
@@ -1,0 +1,6 @@
+- color: c2f232
+  description: Good for newcomers
+  name: good first issue
+- color: "008672"
+  description: ""
+  name: help wanted

--- a/.github/labels/k8s-platforms.yaml
+++ b/.github/labels/k8s-platforms.yaml
@@ -1,0 +1,9 @@
+- color: 3c75ff
+  description: Issue or PR related to Google Kubernetes Engine
+  name: platform/gke
+- color: fc2f4c
+  description: Issue or PR related to OpenShift
+  name: platform/openshift
+- color: 2be0ff
+  description: Issue or PR related to Kind
+  name: platform/kind

--- a/.github/labels/status.yaml
+++ b/.github/labels/status.yaml
@@ -1,0 +1,27 @@
+- color: bc404a
+  description: Issue or PR that is blocked. See comments.
+  name: status/blocked
+- color: fbca04
+  description: Issue or PR that requires in-depth discussion.
+  name: status/discussion-needed
+- color: dddddd
+  description: Issue or PR that is a duplicate of another. See comments.
+  name: status/duplicate
+- color: ef75d3
+  description: Issue or PR that is currently in progress.
+  name: status/in-progress
+- color: DDDDDD
+  description: Issue or PR that doesn't have enough information provided.
+  name: status/incomplete
+- color: e4e669
+  description: Issue or PR that is not valid.
+  name: status/invalid
+- color: 23ce6d
+  description: Issue ready to be worked on.
+  name: status/ready
+- color: 83e298
+  description: Support issues that have been resolved.
+  name: status/resolved
+- color: edd861
+  description: Issue or PR that requires contributor attention.
+  name: status/triage

--- a/.github/labels/type.yaml
+++ b/.github/labels/type.yaml
@@ -1,0 +1,15 @@
+- color: d73a4a
+  description: Issue that reports an unexpected behaviour.
+  name: type/bug
+- color: bfd4f2
+  description: Issue that requests non-user facing changes.
+  name: type/chore
+- color: a2eeef
+  description: Issue that requests a new feature or improvement.
+  name: type/enhancement
+- color: 21ceae
+  description: Issue intended to be exploratory.
+  name: type/research
+- color: ea8cd9
+  description: Issue with general questions or troubleshooting.
+  name: type/support

--- a/.github/workflows/labels-sync.yaml
+++ b/.github/workflows/labels-sync.yaml
@@ -1,0 +1,25 @@
+name: Labels Sync
+on:
+  push:
+    paths:
+      - .github/labels/**.yml
+      - .github/workflows/labels-sync.yaml
+
+jobs:
+  tekton-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name:
+        run: |
+          echo "> Creating config (${{ github.job }}.yaml)..."
+          cat .github/labels/common.yaml >> ${{ github.job }}.yaml
+          cat .github/labels/type.yaml >> ${{ github.job }}.yaml
+          cat .github/labels/status.yaml >> ${{ github.job }}.yaml
+          echo "> Created config:"
+          cat ${{ github.job }}.yaml
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: ${{ github.job }}.yaml
+          repository: buildpacks/tekton-integration
+          token: ${{ secrets.LEARNING_GITHUB_TOKEN }}

--- a/.github/workflows/labels-sync.yaml
+++ b/.github/workflows/labels-sync.yaml
@@ -1,6 +1,8 @@
 name: Labels Sync
 on:
   push:
+    branches:
+      - main
     paths:
       - .github/labels/**.yml
       - .github/workflows/labels-sync.yaml
@@ -16,6 +18,7 @@ jobs:
           cat .github/labels/common.yaml >> ${{ github.job }}.yaml
           cat .github/labels/type.yaml >> ${{ github.job }}.yaml
           cat .github/labels/status.yaml >> ${{ github.job }}.yaml
+          cat .github/labels/k8s-platforms.yaml >> ${{ github.job }}.yaml
           echo "> Created config:"
           cat ${{ github.job }}.yaml
       - uses: micnncim/action-label-syncer@v1
@@ -23,3 +26,5 @@ jobs:
           manifest: ${{ github.job }}.yaml
           repository: buildpacks/tekton-integration
           token: ${{ secrets.LEARNING_GITHUB_TOKEN }}
+          # ! NOTE ! - default is true which deletes labels not in manifest
+          prune: true


### PR DESCRIPTION
This feature is based on an [RFC that proposes syncing labels across repos](https://github.com/buildpacks/rfcs/blob/main/text/0038-gh-repo-labels.md). The implementation is not exactly as proposed given new tools available but the overall result and goal is achieved by this PR.