### PR TITLE
add core team sub-team sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The purpose of this meeting is to sync across the various sub-teams. They tend t
       | Slot | Week A | Week B
       |---   |---     |---
       | Wednesday 11:30am ET (15:30 UTC) |	Implementation |	Platform
+      | Wednesday 02:00pm ET (18:00 UTC) |  Core |  Core
       | Friday 10:00am ET (14:00 UTC) |	Learning |	Buildpack Authors
   * Location: [Zoom](https://vmware.zoom.us/j/91707269913?pwd=bnl1V1JRWWZrSllqaE5rWWp1UHNZdz09)
   * Meeting Notes: [Google Doc](https://docs.google.com/document/d/1zBYJsBwcwLZ5huG4nt7t7kYqaL1W_J12WuLsr2a9mAo/edit)


### PR DESCRIPTION
We've been talking in the leadership meetings to split the leadership meeting in half and move the following itmes into a Core Team sync that is open to the public:

* Review Outstanding Specs
* Release Planning

In addition building on top of the changes proposed in #106, I'd also like to move outstanding RFC review into this meeting too.

If this gets approved, I can make the changes in the meeting notes + team up page.