### PR TITLE
Add more information about the responsibilities of a maintainer

### DIFF
--- a/contributors/guide.md
+++ b/contributors/guide.md
@@ -38,7 +38,7 @@ Additional Capabilities:
 
 #### Maintainer
 
-Maintainers are responsible for advancing the objectives and outcomes of the [sub-teams][sub-teams] they are inducted into.
+Maintainers are responsible for advancing the objectives and outcomes of the [sub-teams][sub-teams] they are inducted into. For detailed information, see the [Maintainer's Guide](maintainer_guide.md).
 
 Additional Responsibilities:
 * Maintain [sub-team][sub-teams] associated contributions.

--- a/contributors/maintainer_guide.md
+++ b/contributors/maintainer_guide.md
@@ -1,0 +1,21 @@
+# Maintainer's Guide
+
+This table aims to provide insight into the role of a CNB Maintainer. The examples given are for the [Implementation Team](https://github.com/buildpacks/community/blob/main/GOVERNANCE.md#implementation-team), and are intended as suggestions (not mandates!). Note that Project Contributors can take on any of the actions listed here, except for the last 3 rows. Thus the road to becoming a maintaner often includes inhabiting the role before assuming the title. For more information, see the [governance](https://github.com/buildpacks/community/blob/main/GOVERNANCE.md#maintainers) page.
+
+| Theme                | What a maintainer does                                 | What that looks like                                                                                         |
+|----------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| Code                 | Contribute code to the lifecycle and imgutil           | Contribute a "major" feature                                                                                 |
+| Code                 | Review PRs to the lifecycle and imgutil                | Be a shepherd of quality; provide feedback on architecture                                                   |
+| Support              | Respond to community inquiries                         | Answer relevant questions in CNCF Slack (#buildpacks and #buildpacks-implementation); reply to GitHub issues |
+| Community            | CNB outreach                                           | Do a presentation about CNB or write a blog post; spotlight community contributions                          |
+| Community            | Identify / mentor new contributors                     | May include programs such as Google Summer of Code or LFX Mentorship                                         |
+| Community            | Represent the team at meetings                         | Deliver release updates during Working Group; facilitate sub-team sync                                       |
+| Deeper conversations | Contribute an RFC                                      |                                                                                                              |
+| Deeper conversations | Contribute to the spec                                 |                                                                                                              |
+| Deeper conversations | Review and comment on RFCs                             | Think about whether an RFC affects the lifecycle                                                             |
+| Planning             | GitHub issue management                                | Create issues on the lifecycle and imgutil; ensure issues are actionable; apply labels to issues as needed   |
+| Planning             | Release planning                                       | Pull issues into the appropriate milestone; take action as necessary to unblock issues                       |
+| Planning             | Release management                                     | Validate release candidate; draft release notes; "push the button"                                           |
+| Maintainer           | Attend leadership meetings                             |                                                                                                              |
+| Maintainer           | Merge PRs to the lifecycle and imgutil                 |                                                                                                              |
+| Maintainer           | [Merge RFCs](https://github.com/buildpacks/rfcs#merge) |                                                                                                              |

--- a/contributors/maintainer_guide.md
+++ b/contributors/maintainer_guide.md
@@ -4,8 +4,8 @@ This table aims to provide insight into the role of a CNB Maintainer. The exampl
 
 | Theme                | What a maintainer does                                 | What that looks like                                                                                         |
 |----------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| Code                 | Contribute code to the lifecycle and imgutil           | Contribute a "major" feature                                                                                 |
-| Code                 | Review PRs to the lifecycle and imgutil                | Be a shepherd of quality; provide feedback on architecture                                                   |
+| Code                 | Contribute a "major" feature | Contribute code to the lifecycle and imgutil                                                                                            |
+| Code                 | Be a shepherd of quality; provide feedback on architecture | Review PRs to the lifecycle and imgutil                                                 |
 | Support              | Respond to community inquiries                         | Answer relevant questions in CNCF Slack (#buildpacks and #buildpacks-implementation); reply to GitHub issues |
 | Community            | CNB outreach                                           | Do a presentation about CNB or write a blog post; spotlight community contributions                          |
 | Community            | Identify / mentor new contributors                     | May include programs such as Google Summer of Code or LFX Mentorship                                         |
@@ -17,5 +17,5 @@ This table aims to provide insight into the role of a CNB Maintainer. The exampl
 | Planning             | Release planning                                       | Pull issues into the appropriate milestone; take action as necessary to unblock issues                       |
 | Planning             | Release management                                     | Validate release candidate; draft release notes; "push the button"                                           |
 | Maintainer           | Attend leadership meetings                             |                                                                                                              |
-| Maintainer           | Merge PRs to the lifecycle and imgutil                 |                                                                                                              |
+| Maintainer           | Merge PRs to the team-maintained repositories                 |                                                                                                              |
 | Maintainer           | [Merge RFCs](https://github.com/buildpacks/rfcs#merge) |                                                                                                              |

--- a/contributors/maintainer_guide.md
+++ b/contributors/maintainer_guide.md
@@ -2,20 +2,20 @@
 
 This table aims to provide insight into the role of a CNB Maintainer. The examples given are for the [Implementation Team](https://github.com/buildpacks/community/blob/main/GOVERNANCE.md#implementation-team), and are intended as suggestions (not mandates!). Note that Project Contributors can take on any of the actions listed here, except for the last 3 rows. Thus the road to becoming a maintaner often includes inhabiting the role before assuming the title. For more information, see the [governance](https://github.com/buildpacks/community/blob/main/GOVERNANCE.md#maintainers) page.
 
-| Theme                | What a maintainer does                                 | What that looks like                                                                                         |
-|----------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| Code                 | Contribute a "major" feature | Contribute code to the lifecycle and imgutil                                                                                            |
-| Code                 | Be a shepherd of quality; provide feedback on architecture | Review PRs to the lifecycle and imgutil                                                 |
-| Support              | Respond to community inquiries                         | Answer relevant questions in CNCF Slack (#buildpacks and #buildpacks-implementation); reply to GitHub issues |
-| Community            | CNB outreach                                           | Do a presentation about CNB or write a blog post; spotlight community contributions                          |
-| Community            | Identify / mentor new contributors                     | May include programs such as Google Summer of Code or LFX Mentorship                                         |
-| Community            | Represent the team at meetings                         | Deliver release updates during Working Group; facilitate sub-team sync                                       |
-| Deeper conversations | Contribute an RFC                                      |                                                                                                              |
-| Deeper conversations | Contribute to the spec                                 |                                                                                                              |
-| Deeper conversations | Review and comment on RFCs                             | Think about whether an RFC affects the lifecycle                                                             |
-| Planning             | GitHub issue management                                | Create issues on the lifecycle and imgutil; ensure issues are actionable; apply labels to issues as needed   |
-| Planning             | Release planning                                       | Pull issues into the appropriate milestone; take action as necessary to unblock issues                       |
-| Planning             | Release management                                     | Validate release candidate; draft release notes; "push the button"                                           |
-| Maintainer           | Attend leadership meetings                             |                                                                                                              |
-| Maintainer           | Merge PRs to the team-maintained repositories                 |                                                                                                              |
-| Maintainer           | [Merge RFCs](https://github.com/buildpacks/rfcs#merge) |                                                                                                              |
+| Theme                | What a maintainer does                                     | What that looks like                                                                                               |
+|----------------------|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Code                 | Contribute a "major" feature                               | Contribute code to team-maintained repositories (e.g., lifecycle and imgutil for Implementation)                   |
+| Code                 | Be a shepherd of quality; provide feedback on architecture | Review PRs to team-maintained repositories                                                                         |
+| Support              | Respond to community inquiries                             | Answer relevant questions in CNCF Slack (e.g., #buildpacks and #buildpacks-implementation); reply to GitHub issues |
+| Community            | CNB outreach                                               | Do a presentation about CNB or write a blog post; spotlight community contributions                                |
+| Community            | Identify / mentor new contributors                         | May include programs such as Google Summer of Code or LFX Mentorship                                               |
+| Community            | Represent the team at meetings                             | Deliver release updates during working group; facilitate sub-team sync                                             |
+| Deeper conversations | Contribute an RFC                                          |                                                                                                                    |
+| Deeper conversations | Contribute to the spec                                     |                                                                                                                    |
+| Deeper conversations | Review and comment on RFCs                                 | Think about whether an RFC affects team-maintained components (e.g., the lifecycle for Implementation)             |
+| Planning             | GitHub issue management                                    | Create issues on team-maintained repositories; ensure issues are actionable; apply labels to issues as needed      |
+| Planning             | Release planning                                           | Pull issues into the appropriate milestone; take action as necessary to unblock issues                             |
+| Planning             | Release management                                         | Validate release candidate; draft release notes; "push the button"                                                 |
+| Maintainer           | Attend leadership meetings                                 |                                                                                                                    |
+| Maintainer           | Merge PRs to team-maintained repositories                  |                                                                                                                    |
+| Maintainer           | [Merge RFCs](https://github.com/buildpacks/rfcs#merge)     |                                                                                                                    |


### PR DESCRIPTION
This was discussed at one point awhile back. The idea is to make the role and process of becoming a maintainer more transparent.