### PR TITLE
Update the emeritus criteria

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -89,7 +89,9 @@ Serving as a member of an open source project requires a huge amount of work tha
 
 Project members should graduate to emeritus status through self-nomination, when they no longer intend to actively fulfill an assigned role in the project. Members holding multiple roles may choose emeritus status for one role while retaining other roles.
 
-When members have not been [active contributors][contributions] for longer than 12 months they may be moved to emertitus by the mechanisms described for each role above. Out of courtesy, a notice for nomination should be given to members that fall under this category prior to being nominated.
+When members have not been [active contributors][contributions] for longer than 3 months they will be moved to emeritus. Out of courtesy, a notice for nomination should be given to members that fall under this category prior to being nominated.
+
+If emeritus members wish to regain an active role, they may skip the normal nomination process and can do so by renewing their contributions for at least two weeks and self-nominating themselves. Active members should welcome such a move. The nomination should be supported by at least one active member from the respective category.
 
 [contributions]: https://github.com/buildpacks/community/blob/main/contributors/guide.md#contributions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -91,7 +91,7 @@ Project members should graduate to emeritus status through self-nomination, when
 
 When members have not been [active contributors][contributions] for longer than 3 months they will be moved to emeritus. Out of courtesy, a notice for nomination should be given to members that fall under this category prior to being nominated.
 
-If emeritus members wish to regain an active role, they may skip the normal nomination process and can do so by renewing their contributions for at least two weeks and self-nominating themselves. Active members should welcome such a move. The nomination should be supported by at least one active member from the respective category.
+If emeritus members in a leadership position in the project (maintainer, team-lead, TOC member) wish to regain an active role, they may skip the normal nomination process and can do so by renewing their contributions for at least two weeks and self-nominating themselves. Active members should welcome such a move. The nomination should be supported by at least one active member from the respective category.
 
 [contributions]: https://github.com/buildpacks/community/blob/main/contributors/guide.md#contributions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -91,7 +91,7 @@ Project members should graduate to emeritus status through self-nomination, when
 
 When members have not been [active contributors][contributions] for longer than 3 months they will be moved to emeritus. Out of courtesy, a notice for nomination should be given to members that fall under this category prior to being nominated.
 
-If emeritus members in a leadership position in the project (maintainer, team-lead, TOC member) wish to regain an active role, they may skip the normal nomination process and can do so by renewing their contributions for at least two weeks and self-nominating themselves. Active members should welcome such a move. The nomination should be supported by at least one active member from the respective category.
+If emeritus members in a leadership position in the project (maintainer, team-lead, TOC member) wish to regain an active role, they may skip the normal nomination process and can do so by renewing their contributions for at least two weeks and self-nominating themselves. Active members should welcome such a move.
 
 [contributions]: https://github.com/buildpacks/community/blob/main/contributors/guide.md#contributions
 


### PR DESCRIPTION
This PR updates the emeritus criteria to enforce a more active offboarding process with a corresponding policy to easily allow emeritus members back if they wish to renew their contributions to the project

Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>