### PR TITLE
Move dfreilich to Emeritus

### DIFF
--- a/TEAMS.md
+++ b/TEAMS.md
@@ -60,7 +60,6 @@
 
 ### Maintainers
 
-[@dfreilich][@dfreilich],
 [@hone][@hone],
 [@jjbustamante][@jjbustamante],
 [@jkutner][@jkutner]
@@ -79,6 +78,7 @@
 
 [@ameyer-pivotal][@ameyer-pivotal],
 [@ashwin-venkatesh][@ashwin-venkatesh],
+[@dfreilich][@dfreilich],
 [@elbandito][@elbandito],
 [@imnitishng][@imnitishng],
 [@importhuman][@importhuman],
@@ -105,13 +105,13 @@
 
 ### Project Contributors
 
-[@dfreilich][@dfreilich],
 [@natalieparellano][@natalieparellano],
 
 ### Emeritus
 
 [@ameyer-pivotal][@ameyer-pivotal],
 [@danielleadams][@danielleadams],
+[@dfreilich][@dfreilich],
 [@dwillist][@dwillist],
 [@elbandito][@elbandito],
 [@jromero][@jromero] (maintainer),


### PR DESCRIPTION
With https://github.com/buildpacks/community/pull/245, and knowing that the project is in good hands, I'd like to take a step back and move to emeritus. 

<img src="https://media0.giphy.com/media/47D5jmVc4f7ylygXYD/giphy.gif"/>

<img src="https://media4.giphy.com/media/29KDhWe2Elaatk6I2p/giphy.gif"/>

