### PR TITLE
Add Sai Kiran as Platform Contributor

### DIFF
--- a/TEAMS.md
+++ b/TEAMS.md
@@ -72,7 +72,8 @@
 [@joshwlewis][@joshwlewis],
 [@matthewmcnew][@matthewmcnew],
 [@natalieparellano][@natalieparellano],
-[@samj1912][@samj1912]
+[@samj1912][@samj1912],
+[@WYGIN][@WYGIN]
 
 ### Emeritus
 


### PR DESCRIPTION
Sai Kiran is our LFX 24 mentee, he already contributed with some `pack` [features](https://github.com/buildpacks/pack/pulls?q=is%3Apr+author%3AWYGIN+is%3Aclosed) in the past

