### PR TITLE
Add Sai Kiran as Platform Contributor

### DIFF
--- a/TEAMS.md
+++ b/TEAMS.md
@@ -74,7 +74,7 @@
 [@matthewmcnew][@matthewmcnew],
 [@natalieparellano][@natalieparellano],
 [@samj1912][@samj1912],
-[@WYGIN][@WYGIN]
+[@WYGIN](https://github.com/WYGIN)
 
 ### Emeritus
 

--- a/TEAMS.md
+++ b/TEAMS.md
@@ -74,7 +74,7 @@
 [@matthewmcnew][@matthewmcnew],
 [@natalieparellano][@natalieparellano],
 [@samj1912][@samj1912],
-[@WYGIN](https://github.com/WYGIN)
+[@WYGIN][@WYGIN]
 
 ### Emeritus
 
@@ -187,3 +187,4 @@
 [@superhighfives]: https://github.com/superhighfives
 [@yaelharel]: https://github.com/yaelharel
 [@zmackie]: https://github.com/zmackie
+[@WYGIN]: https://github.com/WYGIN


### PR DESCRIPTION
Recently, @jjbustamante proposed Sai Kiran(myself) as a Platform Contributor. However, the link provided is not pointing to the GitHub profile. This is regarding the following PR: [Add Sai Kiran as Platform Contributor #252](https://github.com/buildpacks/community/pull/252). Thank You.

![image](https://github.com/buildpacks/community/assets/107541780/f448ec61-ff52-4034-b8ad-f4884e9155a8)

cc: @jjbustamante @hone @samj1912 