### PR TITLE
updated meeting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,56 +24,14 @@ Interested in joining the community of contributors? Learn about how _you_ can j
 
 ### Working Group
 
-Working group meetings are a great place to more directly communicate with other members of the community. They tend to discuss active [RFCs](https://github.com/buildpacks/rfcs) and relay general project information.
-
-##### Details
-
-  * Date/Time: [Thursdays 10am ET / 1pm ET on alternating weeks](https://buildpacks.io/community/#calendar)
-  * Location: [Zoom](https://zoom.us/j/91289548697?pwd=SzNzaHdmVUVBZGhJM20weThIdGdkUT09)
-  * Meeting Notes: [Google Doc](https://docs.google.com/document/d/18gkdfJsy8AQWsOgzPbLRnxN4a-WtUoaCM2Lh7-08rdo/edit)
-  * Video Archives: [YouTube](https://www.youtube.com/playlist?list=PL1p8pquzNvRpDbbgZ0db0MRA-W5_w0G1U)
-  * Meeting Invite: [ICS](https://ics.teamup.com/feed/ksxw26c3km72mq3imn/9046534.ics)
-
-A typical meeting might have the following agenda:
-
-10:00 - 10:15 - introductions, release updates, housekeeping
-10:15 - 10:30 - scheduled topic #1
-10:30 - 10:45 - scheduled topic #2
-10:45 - 11:00 - scheduled topic #3
-
-Topics should be added to the agenda in the public [Google Doc](https://docs.google.com/document/d/18gkdfJsy8AQWsOgzPbLRnxN4a-WtUoaCM2Lh7-08rdo/edit) the day prior to the meeting. The list of topics will be finalized by the meeting organizers. If any scheduled topics are covered in less than the allotted time, additional topics may be covered.
-
-### Team Sync
-
-The purpose of these meetings is to sync across the various teams. They tend to be more technical in nature and go into the "weeds" of ongoing work.
-
-#### Leadership (Team Leads, TOC, and Maintainers)
-
-##### Details
-
-  * Date/Time: [Every other Thursday 1:00pm ET](https://buildpacks.io/community/#calendar)
-  * Location: [Zoom](https://zoom.us/j/94897765769?pwd=ZUJWdTJnTEJuZ0hrV1MxZFN6MGR3Zz09)
-  * Meeting Notes: [Google Doc](https://docs.google.com/document/d/1na9NQ57NFz9DtY-XogddMLL22zVGfImm0E6u-mXwOGA/edit)
-  * Video Archives: [YouTube](https://www.youtube.com/playlist?list=PL1p8pquzNvRrmgWFRihDcjgv8ra2nCiI6)
-  * Meeting Invite: [ICS](https://ics.teamup.com/feed/ksxw26c3km72mq3imn/9046533.ics)
+Working group meetings are a great place to more directly communicate with other members of the community. They tend to discuss active [RFCs](https://github.com/buildpacks/rfcs) and relay general project information. Details on when and how to attend can be found on the [community page](https://buildpacks.io/community/) within the buildpacks.io website.
 
 ### Non-recurring
 
 The CNB community occasionally holds non-recurring meetings to dive deep into certain topics. Meeting minutes can be found below:
 
   * CNB Leadership Summit 2021: [Google Doc](https://drive.google.com/file/d/1FsCd1d1UJ8BW4GIMZBsm52Z3BR6vPBtd/view)
-
-### kpack Working Group
-
-This working group is dedicated to discussing issues and RFCs related to the [kpack project](https://github.com/buildpacks-community/kpack)
-
-##### Details
-
-  * Date/Time: [Every other Tuesday at 10am ET](https://buildpacks.io/community/#calendar)
-  * Location: [Zoom](https://vmware.zoom.us/j/95871799646?pwd=eEF3VXNGSmQrQTJ0eWZTc1B4dHp4UT09)
-  * Meeting Notes: [Google Doc](https://docs.google.com/document/d/1I9n5pVsuos7mJPrzr5YbSPqSXymPaRbhVtcmSGEkUMc/edit)
-  * Meeting Invite: [ICS](https://ics.teamup.com/feed/ksxw26c3km72mq3imn/10287223.ics)
-
+  * Buildpacks Working Session in Paris during KubeCon EU 2024: [Google Doc](https://docs.google.com/document/d/1yUrakKdNixuku_LI7KiQ5Jt5pEysbv6MyjpiiB7rZAw/edit#heading=h.axjq0v2qho8b)
 
 ## Versioning
 We version the various components of our project following a schema described in [VERSIONING.md](VERSIONING.md).


### PR DESCRIPTION
Removed the bulk of info to point to a single source of information - the community page on the website. Also added Joe Kutner's doc from the Buildpacks Working Session under 'non-recurring' meetings. Not saying 'Summit' since we were told by CNCF we explicitly couldn't use that language :P 