### PR TITLE
promote @jjbustamante as platform lead

### DIFF
--- a/TEAMS.md
+++ b/TEAMS.md
@@ -62,8 +62,8 @@
 
 | Member | Organization | Role |
 | :--- | :--- | :--- |
-| [@hone][@hone] | Heroku (Salesforce) | Team Lead, Maintainer |
-| [@jjbustamante][@jjbustamante] | DBAccess | Maintainer |
+| [@jjbustamante][@jjbustamante] | DBAccess | Team Lead, Maintainer |
+| [@hone][@hone] | Heroku (Salesforce) | Maintainer |
 | [@jkutner][@jkutner] | Salesforce | Maintainer |
 | [@edmorley][@edmorley] | Heroku (Salesforce) | Component Maintainer (github-actions), Project Contributor |
 | [@jericop][@jericop] | Rapid7 | Project Contributor |


### PR DESCRIPTION
I propose promoting @jjbustamante as the new lead of the Platform Team. Juan has been the lead maintainer of `pack` for years now. This is long overdue.